### PR TITLE
Add formats 'mo 13/6' and 'Monday 13.06.'

### DIFF
--- a/prolog/abbreviated_dates.pl
+++ b/prolog/abbreviated_dates.pl
@@ -50,6 +50,16 @@ single_day([Context|_], date(Y, M, D), Language, Syntax) -->
   month(M, Language, MonthFormat), b, day_number(D), 
   {maybe_future_year(Context, M, D, Y), atom_concat(MonthFormat,' %d', Syntax)}.
 
+% phrase(abbreviated_dates:single_day([date(2022, 2, 28)], Date, Language, Syntax), `ma 13/6`).
+single_day([Context|_], date(Y, M, D), Language, Syntax) -->
+  week_day(_, Language, WeekDayFormat), b, day_number(D), "/", integer(M),
+  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d/%m', Syntax)}.
+
+% phrase(abbreviated_dates:single_day([date(2022, 2, 28)], Date, Language, Syntax), `Petak 24.06.`).
+single_day([Context|_], date(Y, M, D), Language, Syntax) -->
+  week_day(_, Language, WeekDayFormat), b, day_number(D), ".", integer(M), ".",
+  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d.%m.', Syntax)}.
+
 % phrase(abbreviated_dates:single_day([date(2020, 2, 28)], Date, Language, Syntax), `31`).
 single_day([Context|_], Date, Language, '%d') --> 
   day_number(D), 
@@ -65,7 +75,7 @@ single_day(Context, Date, Language, Syntax) -->
   string(Codes), ",", b, single_day(Context, Date, Language, DaySyntax),
   {
     atom_codes(InputWeekDay, Codes), downcase_atom(InputWeekDay, LowerCaseWeekDay),
-    week_day(Language, _, KnownWeekDay), downcase_atom(KnownWeekDay, LowerCaseWeekDay),
+    week_day_name(Language, _, KnownWeekDay), downcase_atom(KnownWeekDay, LowerCaseWeekDay),
     atom_concat('%A, ', DaySyntax, Syntax)
   }.
 
@@ -85,6 +95,22 @@ month(MonthNumber, Language, '%b') --> % abbreviated month
     atom_codes(Prefix, Abbreviation),
     month_name(Language, MonthNumber, MonthName),
     sub_atom(MonthName, 0, _, _, Prefix)
+  }.
+
+week_day(WeekDayNumber, Language, '%A') --> % explicit week day
+  nonblanks(Codes),
+  {
+    atom_codes(InputWeekDayName, Codes), downcase_atom(InputWeekDayName, LowerCaseWeekDayName),
+    week_day_name(Language, WeekDayNumber , KnownWeekDayName), downcase_atom(KnownWeekDayName, LowerCaseWeekDayName)
+  }.
+
+week_day(WeekDayNumber, Language, '%a') --> % abbreviated week day
+  string(Abbreviation),
+  {
+    atom_codes(Prefix, Abbreviation),
+    week_day_name(Language, WeekDayNumber, WeekDayName),
+    downcase_atom(WeekDayName, LowerCaseWeekDayName),
+    sub_atom(LowerCaseWeekDayName, 0, _, _, Prefix)
   }.
 
 dash --> " - ".
@@ -145,9 +171,9 @@ month_name(Language, MonthNumber, MonthName):-
 	language(Language, Months, _, _, _),
 	nth1(MonthNumber, Months, MonthName).
   
-week_day(Language, WeekNumber, WeekName):-
+week_day_name(Language, WeekDayNumber, WeekDayName):-
 	language(Language, _, Weeks, _, _),
-	nth1(WeekNumber, Weeks, WeekName).
+	nth1(WeekDayNumber, Weeks, WeekDayName).
 
 adverb(Language, Today, Date, Date, today):-
 	language(Language, _, _, Today, _).

--- a/test/test.pl
+++ b/test/test.pl
@@ -38,6 +38,16 @@ parse(date(2020, 2, 28), 'Saturday, 2', Dates, Syntax, Language) ->
    Syntax = ['%A, %d'],
    Language = 'English'.
 
+parse(date(2022, 2, 28), 'ma 13/6', Dates, Syntax, Language) ->
+   Dates = [date(2022, 6, 13)],
+   Syntax = ['%a %d/%m'],
+   Language = 'Dutch'.
+
+parse(date(2022, 2, 28), 'Petak 24.06.', Dates, Syntax, Language) ->
+   Dates = [date(2022, 6, 24)],
+   Syntax = ['%A %d.%m.'],
+   Language = 'Croatian'.
+
 parse(date(2021, 9, 21), 'Friday, 7. May', Dates, Syntax, Language) ->
    Dates = [date(2022, 5, 7)],
    Syntax = ['%A, %d %B'],
@@ -52,6 +62,16 @@ parse(date(2020, 2, 28), '23 Sep. - 27 Sep.', Dates, Syntax, Language) ->
    Dates = [date(2020, 9, 23), date(2020, 9, 27)],
    Syntax = ['%d %b', '%d %b'],
    Language = 'English'.
+
+parse(date(2022, 2, 28), 'ma 13/6 - wo 15/6', Dates, Syntax, Language) ->
+   Dates = [date(2022, 6, 13), date(2022, 6, 15)],
+   Syntax = ['%a %d/%m', '%a %d/%m'],
+   Language = 'Dutch'.
+
+parse(date(2022, 2, 28), 'Ponedjeljak 20.06. - Petak 24.06.', Dates, Syntax, Language) ->
+   Dates = [date(2022, 6, 20), date(2022, 6, 24)],
+   Syntax = ['%A %d.%m.', '%A %d.%m.'],
+   Language = 'Croatian'.
 
 parse(date(2021, 9, 21), 'Today', Dates, Syntax, Language) ->
    Dates = [date(2021, 9, 21)],


### PR DESCRIPTION
This PR adds support for single days in the form of:
- `%a %d/%m`, which is `{abbr. weekday name} {day number}/{month number}`
- `%A %d.%m.`, which is `{Weekday name} {day number}.{month number}.`

Note: the format codes for `%A`, `%a`, and `%m` are taken from https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes.

New tests were added for these new formats as well as date ranges using them.