### PR TITLE
Extend single day

### DIFF
--- a/prolog/abbreviated_dates.pl
+++ b/prolog/abbreviated_dates.pl
@@ -52,13 +52,8 @@ single_day([Context|_], date(Y, M, D), Language, Syntax) -->
 
 % phrase(abbreviated_dates:single_day([date(2022, 2, 28)], Date, Language, Syntax), `ma 13/6`).
 single_day([Context|_], date(Y, M, D), Language, Syntax) -->
-  week_day(_, Language, WeekDayFormat), b, day_number(D), "/", integer(M),
-  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d/%m', Syntax)}.
-
-% phrase(abbreviated_dates:single_day([date(2022, 2, 28)], Date, Language, Syntax), `Petak 24.06.`).
-single_day([Context|_], date(Y, M, D), Language, Syntax) -->
-  week_day(_, Language, WeekDayFormat), b, day_number(D), ".", integer(M), ".",
-  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d.%m.', Syntax)}.
+  week_day(_, Language, WeekDayFormat), optional_comma, b, day_number(D), day_month_separator, month_number(M),
+  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d %m', Syntax)}.
 
 % phrase(abbreviated_dates:single_day([date(2020, 2, 28)], Date, Language, Syntax), `31`).
 single_day([Context|_], Date, Language, '%d') --> 
@@ -81,6 +76,9 @@ single_day(Context, Date, Language, Syntax) -->
 
 day_number(D) --> integer(D).
 day_number(D) --> integer(D), ".".
+month_number(M) --> integer(M).
+month_number(M) --> integer(M), ".".
+day_month_separator --> "."; "/"; "-".
 
 month(MonthNumber, Language, '%B') --> % explicit month
   nonblanks(Codes),
@@ -90,7 +88,7 @@ month(MonthNumber, Language, '%B') --> % explicit month
   }.
 
 month(MonthNumber, Language, '%b') --> % abbreviated month
-  string(Abbreviation), ".",
+  string(Abbreviation), optional_period,
   { 
     atom_codes(Prefix, Abbreviation),
     month_name(Language, MonthNumber, MonthName),
@@ -105,7 +103,15 @@ week_day(WeekDayNumber, Language, '%A') --> % explicit week day
   }.
 
 week_day(WeekDayNumber, Language, '%a') --> % abbreviated week day
-  string(Abbreviation),
+  string(Abbreviation), optional_period,
+  {
+    atom_codes(Prefix, Abbreviation),
+    week_day_name(Language, WeekDayNumber, WeekDayName),
+    sub_atom(WeekDayName, 0, _, _, Prefix)
+  }.
+
+week_day(WeekDayNumber, Language, '%a') --> % abbreviated lower case week day
+  string(Abbreviation), optional_period,
   {
     atom_codes(Prefix, Abbreviation),
     week_day_name(Language, WeekDayNumber, WeekDayName),
@@ -115,6 +121,8 @@ week_day(WeekDayNumber, Language, '%a') --> % abbreviated week day
 
 dash --> " - ".
 b --> white.
+optional_period --> "."; "".
+optional_comma --> ","; "".
 
 %-----------------------------------------------------------
 % Internal predicates

--- a/prolog/abbreviated_dates.pl
+++ b/prolog/abbreviated_dates.pl
@@ -55,6 +55,11 @@ single_day([Context|_], date(Y, M, D), Language, Syntax) -->
   week_day(_, Language, WeekDayFormat), optional_comma, b, day_number(D), day_month_separator, month_number(M),
   {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %d %m', Syntax)}.
 
+% phrase(abbreviated_dates:single_day([date(2022, 2, 28)], Date, Language, Syntax), `Pirm. 06-20`).
+single_day([Context|_], date(Y, M, D), Language, Syntax) -->
+  week_day(_, Language, WeekDayFormat), optional_comma, b, month_number(M), month_day_separator, day_number(D),
+  {maybe_future_year(Context, M, D, Y), atom_concat(WeekDayFormat, ' %m %d', Syntax)}.
+
 % phrase(abbreviated_dates:single_day([date(2020, 2, 28)], Date, Language, Syntax), `31`).
 single_day([Context|_], Date, Language, '%d') --> 
   day_number(D), 
@@ -78,7 +83,8 @@ day_number(D) --> integer(D).
 day_number(D) --> integer(D), ".".
 month_number(M) --> integer(M).
 month_number(M) --> integer(M), ".".
-day_month_separator --> "."; "/"; "-".
+day_month_separator --> "."; "/".
+month_day_separator --> "-".
 
 month(MonthNumber, Language, '%B') --> % explicit month
   nonblanks(Codes),

--- a/prolog/facts/languages.pl
+++ b/prolog/facts/languages.pl
@@ -35,6 +35,11 @@ language('English',
 	['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
 	'Today', 'Tomorrow'
 ).
+language('Estonian',
+	['Jaanuar', 'Veebruar', 'Märts', 'Aprill', 'Mai', 'Juuni', 'Juuli', 'August', 'September', 'Oktoober', 'November', 'Detsember'],
+	['Esmaspäev', 'Teisipäev', 'Kolmapäev', 'Neljapäev', 'Reede', 'Laupäev', 'Pühapäev'],
+	'Täna', 'Homme'
+).
 language('Finnish',
 	['Tammikuu', 'Helmikuu', 'Maaliskuu', 'Huhtikuu', 'Saattaa', 'Kesäkuu', 'Heinäkuu', 'Elokuu', 'Syyskuu', 'Lokakuu', 'Marraskuu', 'Joulukuu'],
 	['Maanantai', 'Tiistai', 'Keskiviikko', 'Torstai', 'Perjantai', 'Lauantai', 'Sunnuntai'],

--- a/prolog/facts/languages.pl
+++ b/prolog/facts/languages.pl
@@ -80,6 +80,11 @@ language('Japanese',
 	['月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日'],
 	'Oggi', 'Domani'
 ).
+language('Latvian',
+	['Janvāris', 'Februāris', 'Marts', 'Aprīlis', 'Maijs', 'Jūnijs', 'Jūlijs', 'Augusts', 'Septembris', 'Oktobris', 'Novembris', 'Decembris'],
+	['Pirmdiena', 'Otrdiena', 'Trešdiena', 'Ceturtdiena', 'Piektdiena', 'Sestdiena', 'Svētdiena'],
+	'Šodien', 'Rīt'
+).
 language('Lithuanian',
 	['Sausis', 'Vasaris', 'Kovas', 'Balandis', 'Gegužė', 'Birželis', 'Liepa', 'Rugpjūtis', 'Rugsėjis', 'Spalis', 'Lapkritis', 'Gruodis'],
 	['Pirmadienis', 'Antradienis', 'Trečiadienis', 'Ketvirtadienis', 'Penktadienis', 'Šeštadienis', 'Sekmadienis'],

--- a/prolog/facts/languages.pl
+++ b/prolog/facts/languages.pl
@@ -78,7 +78,7 @@ language('Italian',
 language('Japanese',
 	['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
 	['月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日'],
-	'Oggi', 'Domani'
+	'今日', '明日'
 ).
 language('Latvian',
 	['Janvāris', 'Februāris', 'Marts', 'Aprīlis', 'Maijs', 'Jūnijs', 'Jūlijs', 'Augusts', 'Septembris', 'Oktobris', 'Novembris', 'Decembris'],

--- a/prolog/facts/languages.pl
+++ b/prolog/facts/languages.pl
@@ -63,7 +63,7 @@ language('Greek',
 language('Hebrew',
 	['ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'],
 	['יום שני', 'יום שלישי', 'יום רביעי', 'יום חמישי', 'יום שישי', 'יום שבת', 'יום ראשון'],
-	'Σήμερα', 'Αύριο'
+	'היום', 'מָחָר'
 ).
 language('Hungarian',
 	['Január', 'Február', 'Március', 'Április', 'Május', 'Június', 'Július', 'Augusztus', 'Szeptember', 'Október', 'November', 'December'],

--- a/test/test.pl
+++ b/test/test.pl
@@ -50,8 +50,8 @@ parse(date(2022, 2, 28), 'Petak 24.06.', Dates, Syntax, Language) ->
 
 parse(date(2022, 2, 28), 'Pirm. 06-20', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 20)],
-   Syntax = ['%A %m %d'],
-   Language = 'Lithuanian'.
+   Syntax = ['%a %m %d'],
+   Language = 'Latvian'.
 
 parse(date(2021, 9, 21), 'Friday, 7. May', Dates, Syntax, Language) ->
    Dates = [date(2022, 5, 7)],

--- a/test/test.pl
+++ b/test/test.pl
@@ -40,12 +40,12 @@ parse(date(2020, 2, 28), 'Saturday, 2', Dates, Syntax, Language) ->
 
 parse(date(2022, 2, 28), 'ma 13/6', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 13)],
-   Syntax = ['%a %d/%m'],
+   Syntax = ['%a %d %m'],
    Language = 'Dutch'.
 
 parse(date(2022, 2, 28), 'Petak 24.06.', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 24)],
-   Syntax = ['%A %d.%m.'],
+   Syntax = ['%A %d %m'],
    Language = 'Croatian'.
 
 parse(date(2021, 9, 21), 'Friday, 7. May', Dates, Syntax, Language) ->
@@ -65,12 +65,12 @@ parse(date(2020, 2, 28), '23 Sep. - 27 Sep.', Dates, Syntax, Language) ->
 
 parse(date(2022, 2, 28), 'ma 13/6 - wo 15/6', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 13), date(2022, 6, 15)],
-   Syntax = ['%a %d/%m', '%a %d/%m'],
+   Syntax = ['%a %d %m', '%a %d %m'],
    Language = 'Dutch'.
 
 parse(date(2022, 2, 28), 'Ponedjeljak 20.06. - Petak 24.06.', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 20), date(2022, 6, 24)],
-   Syntax = ['%A %d.%m.', '%A %d.%m.'],
+   Syntax = ['%A %d %m', '%A %d %m'],
    Language = 'Croatian'.
 
 parse(date(2021, 9, 21), 'Today', Dates, Syntax, Language) ->

--- a/test/test.pl
+++ b/test/test.pl
@@ -48,6 +48,11 @@ parse(date(2022, 2, 28), 'Petak 24.06.', Dates, Syntax, Language) ->
    Syntax = ['%A %d %m'],
    Language = 'Croatian'.
 
+parse(date(2022, 2, 28), 'Pirm. 06-20', Dates, Syntax, Language) ->
+   Dates = [date(2022, 6, 20)],
+   Syntax = ['%A %m %d'],
+   Language = 'Lithuanian'.
+
 parse(date(2021, 9, 21), 'Friday, 7. May', Dates, Syntax, Language) ->
    Dates = [date(2022, 5, 7)],
    Syntax = ['%A, %d %B'],


### PR DESCRIPTION
## New additions
- Adds Estonian and Latvian language support
- Adds support for abbreviated weekdays which are capitalised (e.g. `Wed. 15.06.` rather than only `wed. 15.06.`)
- Adds support for optional commas which may appear after weekdays and weekday abbreviations (e.g. `Wed., 15.06.`)
- Adds support for `single_day` format of `{weekday} {month} {day}` (e.g. `Wed. 06-15`). Here, a `month_day_separator` is defined as `-`.
- Generalises the `single_day` format of `{weekday} {day} {month}` by defining a `day_month_separator` which can be `.` or `/`

## Small fixes
- Fixed copy-paste errors for translations of today/tomorrow in Japanese and Hebrew

## Next steps and opportunities
- Add support for weekday abbreviations that aren't simply a substring of the weekday (as seen in Lithuanian, where št is used for Šeštadienis)
- Connect `day_number` and `month_number` into existing rules regarding the number of days in a given month