### PR TITLE
Refactor grammar

### DIFF
--- a/prolog/abbreviated_dates.plt
+++ b/prolog/abbreviated_dates.plt
@@ -8,7 +8,7 @@
 test('Pirm. 20-06', all(Languages == ['Latvian','Lithuanian'])) :- % Explanation:
   assertion(top_endianness('Latvia', little)), % Latvia little date endianness and first number month day
   assertion(top_country_language('Latvia', 'Lithuanian')),  % Lithuanian speaking population in Latvia
-  phrase(abbreviated_dates:single_day([date(2022, 2, 28)], date(2022, 6, 20), Languages, '%a %m %d'), `Pirm. 20-06`).
+  phrase(abbreviated_dates:single_day([date(2022, 2, 28)], date(2022, 6, 20), Languages, '%a %d %m'), `Pirm. 20-06`).
 
 test('Pirm. 06-20', all(Languages == ['Lithuanian'])) :-
   assertion(top_endianness('Lithuania', big)),

--- a/test/test.pl
+++ b/test/test.pl
@@ -41,7 +41,7 @@ parse(date(2020, 2, 28), 'Saturday, 2', Dates, Syntax, Language) ->
 parse(date(2022, 2, 28), 'ma 13/6', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 13)],
    Syntax = ['%a %d %m'],
-   Language = 'Dutch'.
+   Language = 'Danish'.
 
 parse(date(2022, 2, 28), 'Petak 24.06.', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 24)],
@@ -57,18 +57,6 @@ parse(date(2021, 9, 21), 'saturday, 23 april', Dates, Syntax, Language) ->
    Dates = [date(2022, 4, 23)],
    Syntax = ['%A, %d %B'],
    Language = 'English'.
-
-% Please consider removal of test case since it is indirectly covered by test: '23 Sep.'
-parse(date(2020, 2, 28), '23 Sep. - 27 Sep.', Dates, Syntax, Language) ->
-   Dates = [date(2020, 9, 23), date(2020, 9, 27)],
-   Syntax = ['%d %b', '%d %b'],
-   Language = 'English'.
-
-% Please consider removal of test case since it is indirectly covered by test: 'ma 13/6'
-parse(date(2022, 2, 28), 'ma 13/6 - wo 15/6', Dates, Syntax, Language) ->
-   Dates = [date(2022, 6, 13), date(2022, 6, 15)],
-   Syntax = ['%a %d %m', '%a %d %m'],
-   Language = 'Dutch'.
 
 parse(date(2022, 2, 28), 'Ponedjeljak 20.06. - Petak 24.06.', Dates, Syntax, Language) ->
    Dates = [date(2022, 6, 20), date(2022, 6, 24)],


### PR DESCRIPTION
This PR needs to be reviewed. When running `make test`, 3 tests fail due to an exception (see image [1]), but running these queries manually is successful. Does this maybe have something to do with the migration of test frameworks?

## Summary of changes
- Add `separator` rule, which includes "/"; "-"; "."; " ".
     - This adds support for dates with a space separating the month and day (e.g. format `x, 0. 0.`). 
     - This will drastically improve data collection in HR, CZ, and HU.
- Add support for dates where the weekday is written after the numbers (e.g. `20-06, Pirm.`).
    - This resolves problems in HU and LT
- Also infer syntax based order of month and day (`%d %m` or `%m %d`)
- Combined `day_number` and `month_number` into `date_number`, which simply represents an integer followed optionally by a period.

## Next
- Test these changes and integrate with parser.
- Don't factor in positioning of elements in rules. Instead, focus on e.g. the numeric elements and textual elements.
- Factor in weekday in resolution of day. This adds another verification step to ensure that the date is correct.
