### PR TITLE
Add date endianness data for several countries

### DIFF
--- a/prolog/facts/country_date_endianness.pl
+++ b/prolog/facts/country_date_endianness.pl
@@ -8,7 +8,9 @@ country_date_endianness_population('Albania', [little,big], 2.8).
 country_date_endianness_population('Algeria', [little], 43).
 country_date_endianness_population('Argentina', [little], 45).
 country_date_endianness_population('Australia', [little], 25).
+country_date_endianness_population('Austria', [little], 9).
 country_date_endianness_population('Bangladesh', [little], 166).
+country_date_endianness_population('Belgium', [little], 12).
 country_date_endianness_population('Bhutan', [big], 0.74).
 country_date_endianness_population('Brazil', [little], 210).
 country_date_endianness_population('Cambodia', [little], 16).
@@ -18,8 +20,13 @@ country_date_endianness_population('Cayman Islands', [little,middle], 0.63).
 country_date_endianness_population('China', [big], 1398).
 country_date_endianness_population('Colombia', [little], 51).
 country_date_endianness_population('Congo, Democratic Republic of the', [little], 87).
+country_date_endianness_population('Croatia', [little], 4).
+country_date_endianness_population('Czech Republic', [little], 11).
+country_date_endianness_population('Denmark', [little], 5.8).
 country_date_endianness_population('Egypt', [little], 99).
+country_date_endianness_population('Estonia', [little], 1.3).
 country_date_endianness_population('Ethiopia', [little], 99).
+country_date_endianness_population('Finland', [little], 5.5).
 country_date_endianness_population('France', [little,big], 66).
 country_date_endianness_population('Germany', [little,big], 83).
 country_date_endianness_population('Ghana', [middle,big,little], 30).
@@ -31,6 +38,7 @@ country_date_endianness_population('India', [little,big], 1366).
 country_date_endianness_population('Indonesia', [little], 268).
 country_date_endianness_population('Iran', [little,big], 82).
 country_date_endianness_population('Iraq', [little], 40).
+country_date_endianness_population('Ireland', [little], 5).
 country_date_endianness_population('Italy', [little], 60).
 country_date_endianness_population('Japan', [big], 126).
 country_date_endianness_population('Kenya', [middle,big,little], 52).
@@ -48,6 +56,7 @@ country_date_endianness_population('Nepal', [little,big], 30).
 country_date_endianness_population('Netherlands', [little], 17).
 country_date_endianness_population('New Zealand', [little], 5.0).
 country_date_endianness_population('Nigeria', [little], 193).
+country_date_endianness_population('Norway', [little], 5.4).
 country_date_endianness_population('Pakistan', [little], 212).
 country_date_endianness_population('Panama', [little,middle], 4.2).
 country_date_endianness_population('Papua New Guinea', [little], 8.6).
@@ -58,11 +67,15 @@ country_date_endianness_population('Puerto Rico', [little,middle], 3.2).
 country_date_endianness_population('Romania', [little], 19).
 country_date_endianness_population('Russia', [little,big], 147).
 country_date_endianness_population('Saudi Arabia', [little], 33).
+country_date_endianness_population('Slovakia', [little], 5.5).
+country_date_endianness_population('Slovenia', [little], 2.1).
 country_date_endianness_population('Somalia', [little,middle], 16).
 country_date_endianness_population('South Africa', [middle,big,little], 60).
 country_date_endianness_population('Spain', [little,big], 47).
 country_date_endianness_population('Sri Lanka', [little,big], 22).
 country_date_endianness_population('Sudan', [little], 41).
+country_date_endianness_population('Sweden', [big,little], 10.4).
+country_date_endianness_population('Switzerland', [little], 8.7).
 country_date_endianness_population('Taiwan', [big], 24).
 country_date_endianness_population('Tajikistan', [little], 8.9).
 country_date_endianness_population('Tanzania', [little], 56).


### PR DESCRIPTION
If a country is not listed in `country_date_endianness.pl` and the language is determined from the weekday name, it will fail to parse.

This PR adds **AT, BE, HR, CZ, DK, EE, FI, IE, NO, SK, SI, SE, CH**