### PR TITLE
Fix weekday with comma e.g. (sri, 21. 09.)

### DIFF
--- a/prolog/abbreviated_dates.pl
+++ b/prolog/abbreviated_dates.pl
@@ -124,6 +124,8 @@ month(MonthNumber, Language, '%b') --> % abbreviated month
 
 week_day(InputCodes) --> % abbreviated week day
   string_without(". ", InputCodes), optional_period.
+week_day(InputCodes) --> % abbreviated week day
+  string_without("., ", InputCodes), optional_period.
 
 month_day(Day) --> integer(Day), {between(1, 31, Day)}.
 date_number(N) --> integer(N).

--- a/prolog/abbreviated_dates.plt
+++ b/prolog/abbreviated_dates.plt
@@ -58,6 +58,12 @@ test('day_of_the_week_as_abbreviation'):-
   assertion(Dates == [date(2022,9,14),date(2024,9,14)]),
   assertion(Languages == ['Czech','English','Latvian','Slovak']),
   assertion(Formats == ['%a %d %m']).
+
+test('day_of_the_week_as_abbreviation_with_comma'):-
+  solutions([date(2022, 9, 14)], `sri, 21. 09.`, Dates, Languages, Formats),
+  assertion(Dates == [date(2022,9,21)]),
+  assertion(Languages == ['Croatian']),
+  assertion(Formats == ['%a %d %m']).
   
 test('Capitalized Abbreviated Month Name, Dash Deparated Day & Zero prefixed Month Number',
   all(Languages == ['Latvian','Lithuanian']), all( Format==['%A %m %d']))


### PR DESCRIPTION
This should fix problems observed in the following dates (Croatian):

pon, 19. 09. - sri, 21. 09.
uto, 20. 09. - pon, 26. 09.