### PR TITLE
release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.380
+current_version = 0.0.381
 commit = True
 tag = True
 

--- a/.github/badges/release.svg
+++ b/.github/badges/release.svg
@@ -187,8 +187,8 @@
   <g font-size="110" id="g10815" transform="matrix(0.87421466,0,0,1,18.219814,0)" style="font-size:110px;font-family:Verdana, Geneva, 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#ffffff;text-rendering:geometricPrecision">
     <text x="315" y="150" transform="scale(0.1)" textLength="510" style="fill:#010101;fill-opacity:0.3" id="text11643">Release</text>
     <text x="315" y="140" transform="scale(0.1)" textLength="510" style="fill:#ffffff" id="text11645">Release</text>
-    <text x="875" y="150" transform="scale(0.1)" textLength="450" style="fill:#010101;fill-opacity:0.3" id="text11647">0.0.380</text>
-    <text x="875" y="140" transform="scale(0.1)" textLength="450" style="fill:#ffffff" id="text11649">0.0.380</text>
+    <text x="875" y="150" transform="scale(0.1)" textLength="450" style="fill:#010101;fill-opacity:0.3" id="text11647">0.0.381</text>
+    <text x="875" y="140" transform="scale(0.1)" textLength="450" style="fill:#ffffff" id="text11649">0.0.381</text>
   </g>
   <g id="g4415" transform="matrix(0.07286617,0,0,0.07286617,-5.8406707,0.58625562)">
     <g transform="matrix(1.3333333,0,0,-1.3333333,0,372.31067)" id="g52">

--- a/pack.pl
+++ b/pack.pl
@@ -1,6 +1,6 @@
 name(abbreviated_dates).
 title('Parses abbreviated and ambiguous dates in multiple languages').
-version('0.0.380').
+version('0.0.381').
 
 author('Conrado M. Rodriguez','conrado.rgz@gmail.com').
 maintainer('Conrado M. Rodriguez','conrado.rgz@gmail.com').

--- a/prolog/abbreviated_dates.pl
+++ b/prolog/abbreviated_dates.pl
@@ -185,6 +185,11 @@ single_day([Context|_], Date, Language, Syntax, _) -->
   string(Month), b, month_day(Day),
   {factor_month_day(Context, Day, Month, implicit, Date, Language, MonthFormat), atom_concat(MonthFormat,' %d', Syntax)}.
 
+% phrase(abbreviated_dates:single_day([date(2020, 2, 28)], Date, Language, Syntax), `Jan. 1`).
+single_day([Context|_], Date, Language, Syntax, _) -->
+  string(Month), ".", b, month_day(Day),
+  {factor_month_day(Context, Day, Month, explicit, Date, Language, MonthFormat), atom_concat(MonthFormat,' %d', Syntax)}.
+  
 % DATES HINTING JUST DAYS
 
 % phrase(abbreviated_dates:single_day([date(2020, 2, 28)], Date, Language, Syntax), `31`).

--- a/prolog/abbreviated_dates.plt
+++ b/prolog/abbreviated_dates.plt
@@ -229,6 +229,11 @@ test('Capitalized Implicitly Abbreviated Month Name & Day'):-
   assertion(Languages == ['Danish','Dutch','English','German','Norwegian','Portuguese','Slovenian','Spanish','Swedish']),
   assertion(Formats == ['%b %d']).
 
+test('Capitalized Explicitly Abbreviated Month Name & Day'):-
+  solutions([date(2021, 9, 21)], 'Jun. 17', Dates, Languages, Formats),
+  assertion(Dates == [date(2022,6,17),date(2023,6,17),date(2024,6,17),date(2025,6,17),date(2026,6,17),date(2027,6,17)]),
+  assertion(Languages == ['Danish','Dutch','English','German','Norwegian','Portuguese','Slovenian','Spanish','Swedish']),
+  assertion(Formats == ['%b. %d']).
 
 % DATES HINTING JUST DAYS
 


### PR DESCRIPTION
- Release 0.0.379
- Bump version: 0.0.379 → 0.0.380
- Capitalized Explicitly Abbreviated Month Name & Day
- Bump version: 0.0.380 → 0.0.381
